### PR TITLE
Fix emissions accounting

### DIFF
--- a/R/htmlReportValidation.R
+++ b/R/htmlReportValidation.R
@@ -13,6 +13,13 @@
 #' @import rmarkdown
 #' @export 
 htmlReportValidation <- function(.path, openPromFile) {
+  
+  if (!piamValidation::is_piamValidation()) {
+    message("⚠️ piamValidation is not installed. Skipping HTML report for validation.")
+    message("To enable HTML report for validation, install piamValidation with:")
+    message("install.packages('piamValidation', repos = c('https://pik-piam.r-universe.dev', 'https://cloud.r-project.org'))")
+    return(invisible(NULL))
+  }
 
   configFile <- system.file(package = "postprom", file.path("extdata", "validationConfig_OPEN-PROM.csv"))
 

--- a/R/reportEmissions.R
+++ b/R/reportEmissions.R
@@ -675,7 +675,19 @@ reportEmissions <- function(path, regions, years) {
   magpie_object <- mbind(magpie_object, total_CO2, Navigate_Emissions)
   
   ####################################
+  # Add Emissions|CO2|Energy + Emissions|CO2|Industrial processes to create Emissions|CO2|Industrial Processes
+  print(str(magpie_object))
+  sum <- magpie_object[, ,c("Emissions|CO2|Energy.Mt CO2/yr","Emissions|CO2|Industrial Processes.Mt CO2/yr")]
+  print(str(sum))
+  sum <- dimSums(sum, dim = 3, na.rm = TRUE)
+  print(str(sum))
+  getItems(sum,3) <- "Emissions|CO2|Energy and Industrial Processes.Mt CO2/yr"
+  # Fix separator "p" to "."
+  dimnames(sum)$d3 <- gsub("pMt", ".Mt", dimnames(sum)$d3)
   
+  magpie_object <- mbind(magpie_object, sum)
+  
+  ####################################
   ########for plotting total co2
   # Emissions|CO2|
   

--- a/R/reportEmissions.R
+++ b/R/reportEmissions.R
@@ -360,7 +360,7 @@ reportEmissions <- function(path, regions, years) {
     DAC <- mbind(VCapDAC_total, Enhanced_Weathering, LTDAC, HTDAC, Direct_Air_Capture, H2DAC)
     DAC <- add_dimension(DAC, dim = 3.2, add = "unit", nm = "Mt CO2/yr")
     
-    CDR<- new.magpie(regions, years, "Emissions|CO2|Carbon Dioxide Removal", fill = 0)
+    CDR<- new.magpie(regions, years, "Emissions|CO2|Other Capture and Removal", fill = 0)
     CDR <- add_dimension(CDR, dim = 3.2, add = "unit", nm = "Mt CO2/yr")
     magpie_object <- mbind(magpie_object, CDR)
     
@@ -415,7 +415,7 @@ reportEmissions <- function(path, regions, years) {
     #cdr for plotting
     CDR <- - dimSums(VCapDAC, dim = 3) / 10^6
     CDR <- dimSums(CDR, dim = 3)
-    getItems(CDR, 3) <- "Emissions|CO2|Carbon Dioxide Removal"
+    getItems(CDR, 3) <- "Emissions|CO2|Other Capture and Removal"
     CDR <- add_dimension(CDR, dim = 3.2, add = "unit", nm = "Mt CO2/yr")
     magpie_object <- mbind(magpie_object, CDR)
     
@@ -450,21 +450,6 @@ reportEmissions <- function(path, regions, years) {
     supply_Heat <- district_heating
   }
 
-  total_CO2 <- sum1 + sum2 + supply_Heat + sum4 + sum5 - sum6 + sum7 + remind + hydrogen - hydrogen_CCS + (VCapDAC_total / 10^6) - Industry_CCS
-
-  getItems(total_CO2, 3) <- "Emissions|CO2"
-
-  total_CO2 <- add_dimension(total_CO2, dim = 3.2, add = "unit", nm = "Mt CO2/yr")
-  magpie_object <- mbind(magpie_object, total_CO2, Navigate_Emissions)
-  
-  ####################################
-  
-  ########for plotting total co2
-  
-  plotting_total_co2 <- total_CO2
-  getItems(plotting_total_co2, 3.1) <- "Emissions|CO2|"
-  magpie_object <- mbind(magpie_object, plotting_total_co2)
-  
   ########################
 
   # Hydrogen
@@ -595,20 +580,7 @@ reportEmissions <- function(path, regions, years) {
   sum_Demand <- add_dimension(sum_Demand, dim = 3.2, add = "unit", nm = "Mt CO2/yr")
   magpie_object <- mbind(magpie_object, sum_Demand)
 
-  # Emissions|CO2|Energy|Supply
-  # input to power generation sector, sum2
-  # input to district heating plants + VmTransfInputCHPlants = supply_Heat
-  # consumption of energy branch, sum4
-  # CO2 captured by CCS plants in power generation, sum6
-  # Emissions|CO2|Energy|Supply|Hydrogen
-  sum_Supply <- sum2 + supply_Heat + sum4 - sum6 + Emissions_Supply_Hydrogen
-
-  getItems(sum_Supply, 3) <- "Emissions|CO2|Energy|Supply"
-
-  sum_Supply <- add_dimension(sum_Supply, dim = 3.2, add = "unit", nm = "Mt CO2/yr")
-  magpie_object <- mbind(magpie_object, sum_Supply)
-  
-  Emissions_Supply_Electricity <- sum2 + sum4 - sum6
+  Emissions_Supply_Electricity <- sum2 - sum6
   
   getItems(Emissions_Supply_Electricity, 3) <- "Emissions|CO2|Energy|Supply|Electricity"
   
@@ -627,7 +599,7 @@ reportEmissions <- function(path, regions, years) {
   
   own_consumption <- sum4
   
-  getItems(own_consumption, 3) <- "Emissions|CO2|Energy|Supply|Own Consumption"
+  getItems(own_consumption, 3) <- "Emissions|CO2|Energy|Supply|Autoproduction"
   own_consumption <- add_dimension(own_consumption, dim = 3.2, add = "unit", nm = "Mt CO2/yr")
   magpie_object <- mbind(magpie_object, own_consumption)
   
@@ -652,18 +624,37 @@ reportEmissions <- function(path, regions, years) {
   supply_Liquids <- dimSums(supply_Liquids, 3, na.rm = TRUE)
   supply_Solids <- dimSums(supply_Solids, 3, na.rm = TRUE)
   supply_Gases <- dimSums(supply_Gases, 3, na.rm = TRUE)
-  #supply_Heat <- dimSums(supply_Heat, 3, na.rm = TRUE)
-  
-  getItems(supply_Liquids, 3) <- paste0("Emissions|CO2|Energy|Supply|Liquids")
-  getItems(supply_Solids, 3) <- paste0("Emissions|CO2|Energy|Supply|Solids")
-  getItems(supply_Gases, 3) <- paste0("Emissions|CO2|Energy|Supply|Gases")
+  # supply_Heat <- dimSums(supply_Heat, 3, na.rm = TRUE)
+  # getItems(supply_Liquids, 3) <- paste0("Emissions|CO2|Energy|Supply|Liquids")
+  # getItems(supply_Solids, 3) <- paste0("Emissions|CO2|Energy|Supply|Solids")
+  # getItems(supply_Gases, 3) <- paste0("Emissions|CO2|Energy|Supply|Gases")
   getItems(supply_Heat, 3) <- paste0("Emissions|CO2|Energy|Supply|Heat")
-  
+
+  # TEMPORARY FIX!!!!!! 
+  supply_Liquids <- new.magpie(regions, years, "Emissions|CO2|Energy|Supply|Liquids", fill = 0)
+  supply_Solids <- new.magpie(regions, years, "Emissions|CO2|Energy|Supply|Solids", fill = 0)
+  supply_Gases <- new.magpie(regions, years, "Emissions|CO2|Energy|Supply|Gases", fill = 0)
+    
   supply_per_category <- mbind(supply_Liquids, supply_Solids, supply_Gases, supply_Heat)
   
   supply_per_category <- add_dimension(supply_per_category, dim = 3.2, add = "unit", nm = "Mt CO2/yr")
   
   magpie_object <- mbind(magpie_object, supply_per_category)
+
+  # Emissions|CO2|Energy|Supply
+  # input to power generation sector, sum2
+  # input to district heating plants + VmTransfInputCHPlants = supply_Heat
+  # consumption of energy branch, sum4
+  # CO2 captured by CCS plants in power generation, sum6
+  # Emissions|CO2|Energy|Supply|Hydrogen
+  # Add Emissions|CO2|Supply|Gases + Emissions|CO2|Supply|Liquids + Emissions|CO2|Supply|Solids:
+  # supply_Liquids + supply_Solids + supply_Gases
+  sum_Supply <- Emissions_Supply_Electricity + supply_Heat + sum4  + Emissions_Supply_Hydrogen + supply_Liquids + supply_Solids + supply_Gases
+
+  getItems(sum_Supply, 3) <- "Emissions|CO2|Energy|Supply"
+
+  sum_Supply <- add_dimension(sum_Supply, dim = 3.2, add = "unit", nm = "Mt CO2/yr")
+  magpie_object <- mbind(magpie_object, sum_Supply)
 
   # Emissions|CO2|Energy
   # Emissions|CO2|Energy|Demand, sum_Demand
@@ -675,6 +666,22 @@ reportEmissions <- function(path, regions, years) {
 
   sum_Energy <- add_dimension(sum_Energy, dim = 3.2, add = "unit", nm = "Mt CO2/yr")
   magpie_object <- mbind(magpie_object, sum_Energy)
+
+  # Emissions|CO2
+  total_CO2 <- sum_Supply + sum_Demand + remind + (VCapDAC_total / 10^6) 
+  getItems(total_CO2, 3) <- "Emissions|CO2"
+
+  total_CO2 <- add_dimension(total_CO2, dim = 3.2, add = "unit", nm = "Mt CO2/yr")
+  magpie_object <- mbind(magpie_object, total_CO2, Navigate_Emissions)
+  
+  ####################################
+  
+  ########for plotting total co2
+  # Emissions|CO2|
+  
+  plotting_total_co2 <- total_CO2
+  getItems(plotting_total_co2, 3.1) <- "Emissions|CO2|"
+  magpie_object <- mbind(magpie_object, plotting_total_co2)
 
   # Emissions|CO2|Cumulated
 

--- a/R/reportFinalEnergy.R
+++ b/R/reportFinalEnergy.R
@@ -273,7 +273,7 @@ reportFinalEnergy <- function(path, regions, years) {
     getItems(Direct_Air_Capture_H2DAC_ELC, 3) <- "Final Energy|Direct Air Capture|H2DAC|ELC"
     
     Carbon_Dioxide_Removal <- dimSums(VmConsFuelTechDACProd, dim = 3)
-    getItems(Carbon_Dioxide_Removal, 3) <- "Final Energy|Carbon Dioxide Removal"
+    getItems(Carbon_Dioxide_Removal, 3) <- "Final Energy|Other Capture and Removal"
     
     DAC <- mbind(
       VmConsFuelTechDACProd_EWDAC, VmConsFuelTechDACProd_EWDAC2,
@@ -286,7 +286,7 @@ reportFinalEnergy <- function(path, regions, years) {
     magpie_object <- mbind(magpie_object, DAC)
     
   } else {
-    CDR<- new.magpie(regions, years, "Final Energy|Carbon Dioxide Removal", fill = 0)
+    CDR<- new.magpie(regions, years, "Final Energy|Other Capture and Removal", fill = 0)
     CDR <- add_dimension(CDR, dim = 3.2, add = "unit", nm = "Mtoe")
     magpie_object <- mbind(magpie_object, CDR)
   }

--- a/inst/extdata/plot_mapping.csv
+++ b/inst/extdata/plot_mapping.csv
@@ -6,13 +6,13 @@ Emissions|CO2|Total,Energy|Demand|Transportation
 Emissions|CO2|Total,Energy|Supply
 Emissions|CO2|Total,AFOLU
 Emissions|CO2|Total,Industrial Processes
-Emissions|CO2|Total,Carbon Dioxide Removal
+Emissions|CO2|Total,Other Capture and Removal
 Emissions|CO2|Total,
 Emissions|CO2|Total,VAL
 Emissions|CO2|Cumulated,Cumulated
 Emissions|CO2|Cumulated,Budget1p5C
 Emissions|CO2|Cumulated,Budget2C
-Final Energy|Sector,Carbon Dioxide Removal
+Final Energy|Sector,Other Capture and Removal
 Final Energy|Sector,Industry
 Final Energy|Sector,Transportation
 Final Energy|Sector,Residential and Commercial

--- a/inst/extdata/plotstyle.csv
+++ b/inst/extdata/plotstyle.csv
@@ -43,7 +43,7 @@ Final Energy|Industry,Industry,orange,bar
 Final Energy|Transportation,Transportation,black,bar
 Final Energy|Residential and Commercial,Res and Com,red,bar
 Final Energy|Biomass,Biomass,#00b219,bar
-Final Energy|Carbon Dioxide Removal,CDR,blue,bar
+Final Energy|Other Capture and Removal,CDR,blue,bar
 Final Energy|VAL,IEA,red,dLine
 Final Energy|Industry|VAL,Industry|IEA,purple,dLine
 Final Energy|Transportation|VAL,Transportation|IEA,green,dLine
@@ -54,7 +54,7 @@ Emissions|CO2|Budget1p5C,Budget1p5C,black,dLine
 Emissions|CO2|Budget2C,Budget2C,red,dLine
 Emissions|CO2|,Total,red,dLine
 Emissions|CO2|VAL,PIK,black,dLine
-Emissions|CO2|Carbon Dioxide Removal,CDR,#87e6a4,bar
+Emissions|CO2|Other Capture and Removal,CDR,#87e6a4,bar
 Emissions|CO2|AFOLU,AFOLU,#595933,bar
 Emissions|CO2|Industrial Processes,Industrial Processes,#661a00,bar
 Emissions|CO2|Energy|Demand|Industry,Industry,orange,bar

--- a/inst/extdata/prom-socdr-edition-3-template.csv
+++ b/inst/extdata/prom-socdr-edition-3-template.csv
@@ -1,0 +1,26 @@
+socdr_edition_3_template,OPEN_PROM
+Carbon Capture|IndustrialProcesses,Carbon Capture|Industry
+Carbon Removal,Carbon Capture
+Carbon Removal|Enhanced Weathering,Carbon Capture|Enhanced Weathering
+Carbon Removal|Geological Storage,Carbon Capture|Geological Storage
+Carbon Removal|Geological Storage|Biomass,Carbon Capture|Geological Storage|Biomass
+Carbon Removal|Geological Storage|Direct Air Capture,Carbon Capture|Geological Storage|Direct Air Capture
+Carbon Removal|Geological Storage|Other Sources,Carbon Capture|Geological Storage|Other Sources
+Carbon Removal|Land Use,Carbon Capture|Land Use
+Final Energy|Geothermal,Final Energy|Geothermal heat
+Final Energy|Solar,Final Energy|Solar energy
+Final Energy|Carbon Management|Direct Air Capture,Final Energy|Direct Air Capture
+Final Energy|Carbon Management|Enhanced Weathering,Final Energy|Enhanced Weathering
+Final Energy|Geothermal,Final Energy|Geothermal heat
+Final Energy|Iron and Steel,Final Energy|IS
+Final Energy|Non-Metallic Minerals,Final Energy|BM
+Final Energy|Chemicals,Final Energy|CH
+Final Energy|Non-Ferrous Metals,Final Energy|NF
+Final Energy|Pulp and Paper,Final Energy|PP
+Final Energy|Non-Energy Use,Final Energy|Non Energy
+Final Energy|Solar,Final Energy|Solar energy
+Final Energy|Transportation|Bus,Final Energy|Transportation|PB
+Final Energy|Transportation|Passenger,Final Energy|Transportation|PC
+Final Energy|Transportation|Rail,Final Energy|Transportation|PT
+Final Energy|Transportation|Truck,Final Energy|Transportation|GU
+Final Energy|Transportation|Domestic Aviation,Final Energy|Transportation|PA


### PR DESCRIPTION
### To-do

- [x] Why we have sum4 in total and not in energy_supply? It was a bug, now it is fixed.
- [x] Add certain categories for running MAGICC.
- [x] "Emissions|CO2"  must include the Supply|Gases +Supply|Liquids+Supply|Solids however now (5/11/2025) these categories are put as zero.
- [x] DAC and other carbon capture to "Emissions\|CO2\|Other   Capture and Removal"
- [x] Check emission factor of biomass in postprom
- [x] Emissions|CO2|AFOLU includes the carbon removal of land. Both of them are from Navigate.
- [x] Add "Own consumption" as "Autoproduction".
