### PR TITLE
Update projectReport.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: postprom
 Type: Package
 Title: A Tool for Comparative Analysis of OPEN-PROM Data
-Version: 0.13.5
+Version: 0.13.6
 Authors@R: c(
     person(
       "Michael", "Madianos",

--- a/R/projectReport.R
+++ b/R/projectReport.R
@@ -242,7 +242,7 @@ prepareProjectReportScenario <- function(dataMagpie, project, map) {
 
   filteredMagpie <- dataMagpie[, , keepNames]
 
-  usd2015to2010 <- 0.9253
+  usd2015to2010 <- 1 / 1.087  # 1.087 is from calcIEnvPolicies.R (line 61) in mrprom, used to convert 2010 to 2015 USD. Here we need the inverse to convert 2015 to 2010 USD.
   finalResults <- convertUnitsToExpected(
     magpieObj = filteredMagpie,
     unitTable = checkUnits,


### PR DESCRIPTION
The number used to convert $2010 to $2015 is 1.087 in `mrprom`. It is correct as checked on this [website](https://www.in2013dollars.com/us/inflation/2010?endYear=2015&amount=1). When creating the report for UPTAKE, we need to do the inverse conversion.